### PR TITLE
Update start.sh to latest novnc script name

### DIFF
--- a/vnc/start.sh
+++ b/vnc/start.sh
@@ -5,7 +5,8 @@ iptables -A INPUT -p tcp --dport 80 -i resin-vpn -j ACCEPT
 iptables -A INPUT -p tcp --dport 80 -j REJECT
 
 # Rename the files to allow for default connection html page
+rm /noVNC/index.html
 ln -s /noVNC/vnc.html /noVNC/index.html
 
 # Start noVNC
-/noVNC/utils/launch.sh --vnc 127.0.0.1:5900 --listen 80
+/noVNC/utils/novnc_proxy --vnc 127.0.0.1:5900 --listen 80


### PR DESCRIPTION
The noVNC project has updated the command to invoke the application. It went from /utils/launch.sh to /utils/novnc_proxy per this commit: https://github.com/novnc/noVNC/commit/89e206c14601712cc713ce6f64e2f27f292bc3c5

I've also added a remove command to the /noVNC/index.html file; since, that step sends a warning on subsequent builds.